### PR TITLE
Add documentation for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Archer is a simple, lightweight queue/job worker that uses PostgreSQL as its backing store. It aims to provide an easy-to-use API for defining, enqueuing, and executing background jobs in your Go applications.
 
+For detailed documentation, see [the docs](https://github.com/dyaksa/archer/tree/main/docs).
+
 ## Features
 
 - `Simple API` – Define and register your jobs easily.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/docs/dag.md
+++ b/docs/dag.md
@@ -1,0 +1,32 @@
+# DAG
+
+Archer includes a small package for composing tasks as a directed acyclic graph (DAG). Each node represents a unit of work and can depend on the output of previous nodes.
+
+## Creating a DAG
+
+A DAG is constructed from nodes. Each node has an ID, a `Run` function, optional edges to other nodes and may reference a sub-DAG.
+
+```go
+n1 := &dag.Node{ID: "start", Run: func(ctx context.Context, in any) (any, error) {
+    // do something
+    return in, nil
+}}
+
+n2 := &dag.Node{ID: "finish", Run: func(ctx context.Context, in any) (any, error) {
+    return in, nil
+}}
+
+n1.Edges = []dag.Edge{{To: "finish"}}
+
+flow := dag.New(n1)
+flow.AddNode(n2)
+```
+
+Execute the graph with:
+
+```go
+out, err := flow.Execute(ctx, input)
+```
+
+Edges may have a condition or be executed for each item in a slice. See the `dag` package for more details.
+

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,55 @@
+# Getting Started
+
+This guide walks you through installing Archer and running the example worker and client.
+
+## Installation
+
+Archer requires **Go 1.20+** and **PostgreSQL 12+**.
+
+Install the package:
+
+```bash
+go get github.com/dyaksa/archer
+```
+
+Ensure your PostgreSQL database is running and that you have created the `jobs` table. A minimal schema is shown below:
+
+```sql
+CREATE TABLE jobs (
+  id varchar primary key,
+  queue_name varchar not null,
+  status varchar not null,
+  arguments jsonb not null default '{}'::jsonb,
+  result jsonb not null default '{}'::jsonb,
+  last_error varchar,
+  retry_count integer not null default 0,
+  max_retry integer not null default 0,
+  retry_interval integer not null default 0,
+  scheduled_at timestamptz default now(),
+  started_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+CREATE INDEX ON jobs (queue_name);
+CREATE INDEX ON jobs (scheduled_at);
+CREATE INDEX ON jobs (status);
+CREATE INDEX ON jobs (started_at);
+```
+
+## Example
+
+The `example` directory contains a sample worker and client. Start the worker:
+
+```bash
+go run ./example/worker
+```
+
+In another terminal enqueue jobs with:
+
+```bash
+go run ./example/client
+```
+
+Both programs demonstrate registering jobs and scheduling them for execution.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,23 @@
+# Archer Documentation
+
+Welcome to the Archer job queue library documentation. Archer is a lightweight background job system for Go applications that uses PostgreSQL as its backing store.
+
+## Features
+
+- **Simple API** – Register jobs and enqueue tasks with minimal boilerplate.
+- **Backed by PostgreSQL** – Reliable storage with transactional guarantees.
+- **Flexible Worker Pool** – Control worker concurrency and job timeouts.
+- **Context Support** – Cancel or time out jobs gracefully using contexts.
+- **Custom Table Name** – Store jobs in a table of your choosing.
+- **DAG Package** – Build complex workflows using directed acyclic graphs.
+
+## Getting Started
+
+See [Getting Started](getting-started.md) for installation instructions and a quick example.
+
+Additional topics:
+
+- [Usage](usage.md) – Worker and client examples.
+- [Options](options.md) – Configuration options for workers and jobs.
+- [DAG](dag.md) – Using Archer's DAG utilities for complex workflows.
+

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,0 +1,33 @@
+# Options
+
+Archer can be customized with a set of options that control worker behaviour, retry logic and other aspects.
+
+## Worker Registration Options
+
+- `WithInstances(n int)` – number of concurrent workers for a job type.
+- `WithTimeout(d time.Duration)` – job timeout duration.
+- `WithRetryInterval(d time.Duration)` – wait time before retrying a failed job.
+- `WithMaxRetries(n int)` – maximum number of retry attempts.
+
+## Client Options
+
+When creating a client, you can supply database connection information and other parameters:
+
+```go
+c := archer.NewClient(&archer.Options{
+    Addr:     "localhost:5432",
+    User:     "admin",
+    Password: "password",
+    DBName:   "core",
+}, archer.WithSetTableName("outbox"))
+```
+
+- `Addr` – PostgreSQL host and port.
+- `User` – database user.
+- `Password` – user's password.
+- `DBName` – database name.
+- `WithSetTableName(name string)` – store jobs in a custom table.
+- `WithSleepInterval(d time.Duration)` – delay between polling cycles for new jobs.
+- `WithReaperInterval(d time.Duration)` – interval for cleaning up finished or dead jobs.
+- `WithErrHandler(func(error))` – custom error handler for worker errors.
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,64 @@
+# Usage
+
+Archer exposes a `Client` that manages workers and job scheduling.
+
+## Worker Example
+
+Below is a simplified worker that processes `call_api` jobs. Each job receives a context and a `job.Job` from which you can parse arguments:
+
+```go
+func CallClient(ctx context.Context, job job.Job) (any, error) {
+    args := CallApiArgs{}
+    if err := job.ParseArguments(&args); err != nil {
+        return nil, err
+    }
+
+    // perform work here
+    return CallApiResults{StatusCode: 200}, nil
+}
+
+func main() {
+    c := archer.NewClient(&archer.Options{
+        Addr:     "localhost:5432",
+        Password: "password",
+        User:     "admin",
+        DBName:   "core",
+    })
+
+    c.Register("call_api", CallClient,
+        archer.WithInstances(1),
+        archer.WithTimeout(1*time.Second),
+    )
+
+    if err := c.Start(); err != nil {
+        panic(err)
+    }
+}
+```
+
+## Client Example
+
+Jobs can be enqueued from anywhere using the same client:
+
+```go
+func main() {
+    c := archer.NewClient(&archer.Options{
+        Addr:     "localhost:5432",
+        Password: "password",
+        User:     "admin",
+        DBName:   "core",
+    })
+
+    _, err := c.Schedule(
+        context.Background(),
+        uuid.NewString(),
+        "call_api",
+        CallApiArgs{URL: "http://localhost:3001/v4/upsert", Method: "POST"},
+        archer.WithMaxRetries(3),
+    )
+    if err != nil {
+        panic(err)
+    }
+}
+```
+


### PR DESCRIPTION
## Summary
- document how to use Archer in `docs/`
- link docs from the README

## Testing
- `go test ./...` *(fails: downloading modules blocked)*

------
https://chatgpt.com/codex/tasks/task_b_685cb84d22e88332be8ee032c957cd14