### PR TITLE
feat: worker options untuk success/failed callback + contoh penggunaan

### DIFF
--- a/client.go
+++ b/client.go
@@ -162,7 +162,7 @@ func (c *Client) start() {
 		q := c.queue(name)
 
 		for i := 0; i < config.instances; i++ {
-			s := newPool(q, c.mutate, config.w, c.sleepInterval)
+			s := newPool(q, c.mutate, config.w, c.sleepInterval, config.callbackSuccess)
 			c.spawn.Spawn(s)
 		}
 

--- a/client.go
+++ b/client.go
@@ -162,7 +162,7 @@ func (c *Client) start() {
 		q := c.queue(name)
 
 		for i := 0; i < config.instances; i++ {
-			s := newPool(q, c.mutate, config.w, c.sleepInterval, config.callbackSuccess)
+			s := newPool(q, c.mutate, config.w, c.sleepInterval, config.callbackSuccess, config.callbackFailed)
 			c.spawn.Spawn(s)
 		}
 

--- a/example/callback-options/README.md
+++ b/example/callback-options/README.md
@@ -1,0 +1,61 @@
+# Callback Options Example
+
+Contoh sederhana penggunaan opsi callback pada worker Archer. Contoh ini menunjukkan:
+- Callback sukses: dipanggil setelah job selesai dan status tersimpan.
+- Callback gagal: dipanggil setelah job gagal (tanpa retry tersisa) dan status tersimpan.
+
+## Prasyarat
+- Go 1.20+.
+- PostgreSQL berjalan lokal dan tabel `jobs` tersedia.
+- Update konfigurasi koneksi di `client/main.go` dan `worker/main.go` sesuai lingkungan Anda (host, user, password, dbname, dan nama tabel jika perlu).
+
+Schema minimal tabel `jobs` (lihat juga README utama):
+
+```sql
+CREATE TABLE jobs (
+  id varchar primary key,
+  queue_name varchar not null,
+  status varchar not null,
+  arguments jsonb not null default '{}'::jsonb,
+  result jsonb not null default '{}'::jsonb,
+  last_error varchar,
+  retry_count integer not null default 0,
+  max_retry integer not null default 0,
+  retry_interval integer not null default 0,
+  scheduled_at timestamptz default now(),
+  started_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+CREATE INDEX ON jobs (queue_name);
+CREATE INDEX ON jobs (scheduled_at);
+CREATE INDEX ON jobs (status);
+CREATE INDEX ON jobs (started_at);
+```
+
+## Struktur
+- `worker/main.go`: Mendaftarkan worker `call_test_callback` serta `WithCallbackSuccess` dan `WithCallbackFailed`.
+- `client/main.go`: Menjadwalkan dua job — satu yang gagal (method `POST`) dan satu yang sukses (method `PUT`).
+
+## Menjalankan
+Jalankan dari root repo.
+
+1) Jalankan worker
+```bash
+go run ./example/callback-options/worker
+```
+
+2) Pada terminal lain, jalankan client untuk menjadwalkan job
+```bash
+go run ./example/callback-options/client
+```
+
+Jika koneksi DB benar dan tabel tersedia, Anda akan melihat di log worker:
+- Untuk job dengan method `POST` → eksekusi gagal → callback gagal dieksekusi → log "Job failed" beserta `retry_count`.
+- Untuk job dengan method `PUT` → eksekusi berhasil → callback sukses dieksekusi → log "Job completed successfully".
+
+## Catatan
+- Callback dieksekusi setelah status job dipersist, sehingga tidak mempengaruhi mekanisme retry/reaper.
+- Opsi callback bersifat opsional; jika tidak disetel, tidak ada efek samping.
+

--- a/example/callback-options/client/main.go
+++ b/example/callback-options/client/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/dyaksa/archer"
+	"github.com/google/uuid"
+)
+
+type CallTestCallbackArgs struct {
+	URL    string
+	Method string
+	Body   any
+}
+
+type DataDto struct {
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+func main() {
+	c := archer.NewClient(&archer.Options{
+		Addr:     "localhost:5433",
+		Password: "azozink",
+		User:     "postgres",
+		DBName:   "local_fabd_revenue",
+	}, archer.WithSetTableName("jobs"))
+
+	dto := DataDto{
+		Name:     "John",
+		Email:    "sample@gmail.com",
+		Password: "sample123",
+	}
+
+	_, err := c.Schedule(
+		context.Background(),
+		uuid.NewString(),
+		"call_test_callback",
+		CallTestCallbackArgs{URL: "http://localhost:3001/v4/upsert", Method: "POST", Body: dto},
+		archer.WithMaxRetries(1),
+		archer.WithRetryInterval(2*time.Second),
+	)
+
+	if err != nil {
+		slog.Error("error", "err", err)
+		return
+	}
+
+	slog.Info("done")
+}

--- a/example/callback-options/client/main.go
+++ b/example/callback-options/client/main.go
@@ -35,17 +35,33 @@ func main() {
 		Password: "sample123",
 	}
 
+	// Callback Failed
 	_, err := c.Schedule(
 		context.Background(),
 		uuid.NewString(),
 		"call_test_callback",
 		CallTestCallbackArgs{URL: "http://localhost:3001/v4/upsert", Method: "POST", Body: dto},
-		archer.WithMaxRetries(1),
+		archer.WithMaxRetries(3),
 		archer.WithRetryInterval(2*time.Second),
 	)
 
 	if err != nil {
 		slog.Error("error", "err", err)
+		return
+	}
+
+	// Callback Success
+	_, err2 := c.Schedule(
+		context.Background(),
+		uuid.NewString(),
+		"call_test_callback",
+		CallTestCallbackArgs{URL: "http://localhost:3001/v4/upsert", Method: "PUT", Body: dto},
+		archer.WithMaxRetries(3),
+		archer.WithRetryInterval(2*time.Second),
+	)
+
+	if err2 != nil {
+		slog.Error("error", "err", err2)
 		return
 	}
 

--- a/example/callback-options/worker/main.go
+++ b/example/callback-options/worker/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/dyaksa/archer"
+	"github.com/dyaksa/archer/job"
+)
+
+type CallTestCallbackArgs struct {
+	URL    string
+	Method string
+	Body   any
+}
+
+type CallTestCallbackResults struct {
+	Message string `json:"message"`
+}
+
+func CallTestCallback(ctx context.Context, job job.Job) (any, error) {
+	args := CallTestCallbackArgs{}
+	if err := job.ParseArguments(&args); err != nil {
+		return nil, err
+	}
+
+	time.Sleep(10 * time.Second)
+
+	slog.Info("started job request id: " + job.ID)
+	defer func() {
+		slog.Info("finished job request id: " + job.ID)
+	}()
+
+	res := CallTestCallbackResults{Message: "Success!"}
+
+	return res, nil
+}
+
+func CallTestCallbackSuccess(ctx context.Context, job job.Job) (any, error) {
+	slog.Info("Job completed successfully", "job_id", job.ID)
+
+	return map[string]any{
+		"callback_executed": true,
+		"job_id":            job.ID,
+		"completed_at":      time.Now(),
+	}, nil
+}
+
+func CallTestCallbackFailed(ctx context.Context, job job.Job) (any, error) {
+	slog.Info(fmt.Sprintf("Job failed retry for : %d", job.RetryCount), "job_id", job.ID)
+
+	return map[string]any{
+		"callback_executed": true,
+		"job_id":            job.ID,
+		"retry_count":       job.RetryCount,
+		"failed_at":         time.Now(),
+	}, nil
+}
+
+func main() {
+	c := archer.NewClient(&archer.Options{
+		Addr:     "localhost:5433",
+		Password: "azozink",
+		User:     "postgres",
+		DBName:   "local_fabd_revenue",
+	}, archer.WithSetTableName("jobs"))
+
+	c.Register("call_test_callback", CallTestCallback,
+		archer.WithInstances(1),
+		archer.WithTimeout(1*time.Second),
+		archer.WithCallbackSuccess(CallTestCallbackSuccess),
+	)
+
+	if err := c.Start(); err != nil {
+		panic(err)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -53,6 +53,13 @@ func WithCallbackSuccess(fn func(ctx context.Context, job job.Job) (any, error))
 	}
 }
 
+func WithCallbackFailed(fn func(ctx context.Context, job job.Job) (any, error)) WorkerOptionFunc {
+	return func(r registerConfig) registerConfig {
+		r.callbackFailed = fn
+		return r
+	}
+}
+
 type ClientOptionFunc func(*Client) *Client
 
 func WithSetTableName(table string) ClientOptionFunc {

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package archer
 
 import (
+	"context"
 	"time"
 
 	"github.com/dyaksa/archer/job"
@@ -41,6 +42,13 @@ func WithTimeout(t time.Duration) WorkerOptionFunc {
 func WithInstances(i int) WorkerOptionFunc {
 	return func(r registerConfig) registerConfig {
 		r.instances = i
+		return r
+	}
+}
+
+func WithCallbackSuccess(fn func(ctx context.Context, job job.Job) (any, error)) WorkerOptionFunc {
+	return func(r registerConfig) registerConfig {
+		r.callbackSuccess = fn
 		return r
 	}
 }

--- a/pool.go
+++ b/pool.go
@@ -13,10 +13,10 @@ type pool struct {
 	sleepInterval time.Duration
 }
 
-func newPool(q *Queue, m mutate, w Worker, sleepInterval time.Duration, callbackSuccess func(ctx context.Context, job job.Job) (any, error)) *pool {
+func newPool(q *Queue, m mutate, w Worker, sleepInterval time.Duration, callbackSuccess func(ctx context.Context, job job.Job) (any, error), callbackFailed func(ctx context.Context, job job.Job) (any, error)) *pool {
 	return &pool{
 		queue:         *q,
-		handler:       newHandler(w, m, callbackSuccess),
+		handler:       newHandler(w, m, callbackSuccess, callbackFailed),
 		sleepInterval: sleepInterval,
 	}
 }

--- a/pool.go
+++ b/pool.go
@@ -13,10 +13,10 @@ type pool struct {
 	sleepInterval time.Duration
 }
 
-func newPool(q *Queue, m mutate, w Worker, sleepInterval time.Duration) *pool {
+func newPool(q *Queue, m mutate, w Worker, sleepInterval time.Duration, callbackSuccess func(ctx context.Context, job job.Job) (any, error)) *pool {
 	return &pool{
 		queue:         *q,
-		handler:       newHandler(w, m),
+		handler:       newHandler(w, m, callbackSuccess),
 		sleepInterval: sleepInterval,
 	}
 }

--- a/register.go
+++ b/register.go
@@ -12,6 +12,7 @@ type registerConfig struct {
 	instances       int
 	timeout         time.Duration
 	callbackSuccess func(ctx context.Context, job job.Job) (any, error)
+	callbackFailed  func(ctx context.Context, job job.Job) (any, error)
 }
 
 type register map[string]registerConfig

--- a/register.go
+++ b/register.go
@@ -1,13 +1,17 @@
 package archer
 
 import (
+	"context"
 	"time"
+
+	"github.com/dyaksa/archer/job"
 )
 
 type registerConfig struct {
-	w         Worker
-	instances int
-	timeout   time.Duration
+	w               Worker
+	instances       int
+	timeout         time.Duration
+	callbackSuccess func(ctx context.Context, job job.Job) (any, error)
 }
 
 type register map[string]registerConfig


### PR DESCRIPTION
Ringkasan

- Menambahkan opsi callback pada worker untuk dieksekusi saat job sukses atau gagal.
- Menyediakan contoh client/worker untuk mendemonstrasikan alur callback.

Perubahan utama

- options.go: API baru WithCallbackSuccess(fn) dan WithCallbackFailed(fn) sebagai WorkerOptionFunc.
- handler.go: Memanggil callbackFailed saat eksekusi gagal setelah persist; memanggil callbackSuccess saat
berhasil.
- pool.go/register.go/client.go: Wiring callback dari register → pool → handler tanpa mengubah mekanisme
retry/reaper.
- example/callback-options/*: Contoh client menjadwalkan job (kasus sukses/gagal) dan worker yang
meng-setup callback.

Perilaku & kompatibilitas

- Tidak ada breaking change; opsi bersifat opsional (default no-op).
- Callback dieksekusi setelah status job dipersist, tidak mengganggu retry/reaper.

Cara uji manual (singkat)

- Jalankan client di example/callback-options/client untuk menjadwalkan 2 job:
    - Method POST → gagal → trigger callbackFailed.
    - Method PUT → sukses → trigger callbackSuccess.